### PR TITLE
Fix detached state for new release bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   release:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Fixes detached state for actions/checkout to push commit with new version

closes #16
related https://github.com/actions/checkout/issues/6