### PR TITLE
Replace element with more data when merge two PubId

### DIFF
--- a/lib/nist_pubid/document.rb
+++ b/lib/nist_pubid/document.rb
@@ -105,7 +105,12 @@ module NistPubid
     def merge(document)
       document.instance_variables.each do |var|
         val = document.instance_variable_get(var)
-        instance_variable_set(var, val) unless val.nil?
+        current_val = instance_variable_get(var)
+        if [:@serie, :@publisher].include?(var) ||
+            (val && current_val.nil?) ||
+            (val && current_val.to_s.length < val.to_s.length)
+          instance_variable_set(var, val)
+        end
       end
 
       self

--- a/lib/nist_pubid/edition.rb
+++ b/lib/nist_pubid/edition.rb
@@ -11,15 +11,16 @@ module NistPubid
     end
 
     def to_s
+      result = (@sequence && [@sequence]) || []
       if @day
-        Date.new(@year, @month, @day).strftime("%Y%m%d")
+        result << Date.new(@year, @month, @day).strftime("%Y%m%d")
       elsif @month
-        Date.new(@year, @month).strftime("%Y%m")
+        result << Date.new(@year, @month).strftime("%Y%m")
       elsif @year
-        Date.new(@year).strftime("%Y")
-      else
-        @sequence
+        result << Date.new(@year).strftime("%Y")
       end
+
+      result.join("-")
     end
 
     def self.parse(code, serie = nil)

--- a/lib/nist_pubid/serie.rb
+++ b/lib/nist_pubid/serie.rb
@@ -89,17 +89,24 @@ module NistPubid
 
       return nil if edition.nil? || edition.captures.compact.empty?
 
+      result = { parsed: parsed }
+
       if edition.named_captures.key?("date_with_month") && edition[:date_with_month]
         date = Date.parse("01/" + edition[:date_with_month])
-        { month: date.month, year: date.year, parsed: parsed }
+        result[:month] = date.month
+        result[:year] = date.year
       elsif edition.named_captures.key?("date_with_day") && edition[:date_with_day]
         date = Date.parse(edition[:date_with_day])
-        { day: date.day, month: date.month, year: date.year, parsed: parsed }
+        result.merge!({ day: date.day, month: date.month, year: date.year })
       elsif edition.named_captures.key?("year") && edition[:year]
-        { year: edition[:year].to_i, parsed: parsed }
-      else
-        { sequence: edition[:sequence], parsed: parsed }
+        result[:year] = edition[:year].to_i
       end
+
+      if edition.named_captures.key?("sequence") && edition[:sequence]
+        result[:sequence] = edition[:sequence]
+      end
+
+      result
     end
 
     def parse_docnumber(code, code_original)

--- a/lib/nist_pubid/series/nist_hb.rb
+++ b/lib/nist_pubid/series/nist_hb.rb
@@ -1,7 +1,7 @@
 module NistPubid
   module Series
     class NistHb < NistPubid::Serie
-      EDITION_REGEXP = /(?:\d+-)?\d+(?<prepend>-)(?<year>\d{4})/.freeze
+      EDITION_REGEXP = /(?:\d+-)?\d+(?:(?<prefix>e)(?<sequence>\d+))?(?<prepend>-)(?<year>\d{4})/.freeze
 
       def parse_edition(code)
         super(code.sub("NIST HB 105-1-1990", "NIST HB 105-1r1990"))

--- a/spec/nist_pubid/document_spec.rb
+++ b/spec/nist_pubid/document_spec.rb
@@ -1052,5 +1052,13 @@ RSpec.describe NistPubid::Document do
         ).to_s(:short)).to eq("NBS FIPS 107e198503")
       end
     end
+
+    context "NIST HB 133e4-2002" do
+      it do
+        expect(described_class.parse("NIST HB 133e4-2002").merge(
+          described_class.parse("NIST.HB.133e4")
+        ).to_s(:short)).to eq("NIST HB 133e4-2002")
+      end
+    end
   end
 end

--- a/spec/nist_pubid/nist_tech_pubs_spec.rb
+++ b/spec/nist_pubid/nist_tech_pubs_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe NistPubid::NistTechPubs, vcr: true do
   end
 
   describe "#comply_with_pubid" do
+    before do
+      described_class.documents = [
+        { id: "NIST SP 260-14",
+          doi: "NIST.SP.260-14",
+          title: "NIST SP 260-14" },
+      ]
+    end
+
     it "returns identifier comply with NIST PubID" do
       expect(described_class.comply_with_pubid.map { |d| d[:id] })
         .to include("NIST SP 260-14")
@@ -67,6 +75,14 @@ RSpec.describe NistPubid::NistTechPubs, vcr: true do
   end
 
   describe "#different_with_pubid" do
+    before do
+      described_class.documents = [
+        { id: "NISTIR 8379",
+          doi: "NIST.IR.8379",
+          title: "NISTIR 8379" },
+      ]
+    end
+
     it "returns identifiers not comply with NIST PubID" do
       expect(described_class.different_with_pubid.map { |d| d[:id] })
         .to include("NISTIR 8379")


### PR DESCRIPTION
Related to #125
Fixing issue with:
`✅ | NIST HB 133e4 | NIST HB 133e4-2002 |  - | NIST.HB.133e4 | NIST.HB.133e4 | Checking the net contents of packaged goods
`