### PR TITLE
Do not parse volume from revision part

### DIFF
--- a/lib/nist_pubid/document.rb
+++ b/lib/nist_pubid/document.rb
@@ -187,7 +187,6 @@ module NistPubid
 
       (matches[:update_number], matches[:update_year]) = update if update
 
-
       matches[:revision] = nil if matches[:addendum]
 
       matches[:docnumber] = matches[:serie].parse_docnumber(code, code_original)

--- a/lib/nist_pubid/serie.rb
+++ b/lib/nist_pubid/serie.rb
@@ -15,8 +15,8 @@ module NistPubid
     REVISION_REGEXP =
       /(?:[\daA-Z](?:rev|r|Rev\.\s|(?:[0-9]+[A-Za-z]*-[0-9]+[A-Za-z]*-))|, Revision )([\da]+|$|\w+\d{4})/
         .freeze
-    VOLUME_REGEXP = /(?<=\.)?v(?(1)-)(\d+[\w-]*)(?!\.\d+)/.freeze
     UPDATE_REGEXP = /((?<=Upd|Update )\s?[\d:]+|-upd)-?(\d*)/.freeze
+    VOLUME_REGEXP = /(?<=\.)?(?<![a-z])v(?(1)-)(\d+[\w-]*)(?!\.\d+)/.freeze
 
     def initialize(serie:, parsed: nil)
       @serie = serie

--- a/spec/nist_pubid/document_spec.rb
+++ b/spec/nist_pubid/document_spec.rb
@@ -1112,5 +1112,13 @@ RSpec.describe NistPubid::Document do
         ).to_s(:short)).to eq("NIST HB 133e4-2002")
       end
     end
+
+    context "NIST SP 260-126 rev 2013" do
+      it do
+        expect(described_class.parse("NIST SP 260-126 rev 2013").merge(
+          described_class.parse("NIST.SP.260-126rev2013")
+        ).to_s(:short)).to eq("NIST SP 260-126r2013")
+      end
+    end
   end
 end


### PR DESCRIPTION
Related #125 

Fixing these records:
```
✅ | NIST IR 4335v1990rNov1990 | NIST IR 4335rNov1990 | ✅ | NIST.IR.4335v1990rNov1990 | NIST.IR.4335rNov1990 | The NIST PDES toolkit: technical fundamentals
✅ | NIST SP 260-126v2013r2013 | NIST SP 260-126 rev 2013 | ✅ | NIST.SP.260-126v2013r2013 | NIST.SP.260-126rev2013 | The NIST Traceable Reference Material Program for Gas Standards
```