### PR TITLE
Fix parsing for NBS IR parts and volumes

### DIFF
--- a/lib/nist_pubid/document.rb
+++ b/lib/nist_pubid/document.rb
@@ -143,10 +143,20 @@ module NistPubid
 
       code_original = code
 
+      unless ["NBS CSM", "NBS CS", "NBS RPT"].include?(matches[:serie].to_s)
+        parsed_volume, volume = matches[:serie].parse_volume(code)
+        if volume
+          matches[:volume] = volume
+          # replace last occurrence
+          code = code.reverse.sub(parsed_volume.reverse, "").reverse
+        end
+      end
+
       parsed_part, part = matches[:serie].parse_part(code)
       if part
         matches[:part] = part
-        code = code.sub(parsed_part, "")
+        # replace last occurrence
+        code = code.reverse.sub(parsed_part.reverse, "").reverse
       end
       matches[:edition] = Edition.parse(code, matches[:serie])
 
@@ -177,13 +187,12 @@ module NistPubid
 
       (matches[:update_number], matches[:update_year]) = update if update
 
-      unless ["NBS CSM", "NBS CS", "NBS RPT"].include?(matches[:serie].to_s)
-        matches[:volume] = /(?<=(\.))?v(?(1)-)(\d+[\w-]*)(?!\.\d+)/.match(code)&.[](2)
-      end
 
       matches[:revision] = nil if matches[:addendum]
 
       matches[:docnumber] = matches[:serie].parse_docnumber(code, code_original)
+
+      # part, edition, supplement, revision, docnumber, volume
 
       # NIST GCR documents often have a 3-part identifier -- the last part is
       # not revision but is part of the identifier.

--- a/lib/nist_pubid/serie.rb
+++ b/lib/nist_pubid/serie.rb
@@ -11,10 +11,11 @@ module NistPubid
 
     DOCNUMBER_REGEXP = nil
     SUPPLEMENT_REGEXP = /(?:(?:supp?)-?(\d+)?|Supplement|Suppl.)/.freeze
-    PART_REGEXP = /(?<=\.)?(?<![a-z])+(?:pt|Pt|p)(?(1)-)([A-Z\d]+)/.freeze
+    PART_REGEXP = /(?<=\.)?(?<![a-z])+(pt|Pt|p)([A-Z\d]+)/.freeze
     REVISION_REGEXP =
       /(?:[\daA-Z](?:rev|r|Rev\.\s|(?:[0-9]+[A-Za-z]*-[0-9]+[A-Za-z]*-))|, Revision )([\da]+|$|\w+\d{4})/
         .freeze
+    VOLUME_REGEXP = /(?<=\.)?v(?(1)-)(\d+[\w-]*)(?!\.\d+)/.freeze
 
     def initialize(serie:, parsed: nil)
       @serie = serie
@@ -158,18 +159,25 @@ module NistPubid
 
     def parse_part(code)
       part = self.class::PART_REGEXP.match(code)
-      return [part.to_s, part.captures.join] if part
+      return [part.captures.join, part.captures.last] if part
 
       [nil, nil]
     end
 
     def parse_revision(code)
       revision = self.class::REVISION_REGEXP.match(code)&.captures&.compact&.join("-")
-      revision ||= Serie::REVISION_REGEXP.match(code)&.captures&.join unless instance_of?(NistPubid::Serie)
+      # revision ||= Serie::REVISION_REGEXP.match(code)&.captures&.join unless instance_of?(NistPubid::Serie)
 
       revision = "1" if revision&.empty?
 
       revision
+    end
+
+    def parse_volume(code)
+      volume = self.class::VOLUME_REGEXP.match(code)
+      return [volume.captures.join, volume.captures.last] if volume
+
+      [nil, nil]
     end
 
     def self.regexp

--- a/lib/nist_pubid/series/nbs_ir.rb
+++ b/lib/nist_pubid/series/nbs_ir.rb
@@ -1,0 +1,9 @@
+module NistPubid
+  module Series
+    class NbsIr < NistPubid::Serie
+      REVISION_REGEXP = /(?:[\daA-Z](?:rev|r|Rev\.\s)|, Revision )([\da]+|$|\w+\d{4})/.freeze
+      VOLUME_REGEXP = /(?:74-577|77-1420)()-(\d+)/.freeze
+      PART_REGEXP = /(?:\d+-\d+)(-)(\d+)/.freeze
+    end
+  end
+end

--- a/lib/nist_pubid/series/nbs_sp.rb
+++ b/lib/nist_pubid/series/nbs_sp.rb
@@ -1,7 +1,7 @@
 module NistPubid
   module Series
     class NbsSp < NistPubid::Serie
-      PART_REGEXP = /(?<=\.)?(?<![a-z])+(?:pt|Pt|p|P)([A-Z\d]+)/.freeze
+      PART_REGEXP = /(?<=\.)?(?<![a-z])+(pt|Pt|p|P)([A-Z\d]+)/.freeze
     end
   end
 end

--- a/spec/nist_pubid/document_spec.rb
+++ b/spec/nist_pubid/document_spec.rb
@@ -946,6 +946,34 @@ RSpec.describe NistPubid::Document do
       it_behaves_like "converts pubid to different formats"
     end
 
+    context "NBS IR 74-577-1" do
+      let(:original_pubid) { "NBS IR 74-577-1" }
+      let(:short_pubid) { "NBS IR 74-577v1" }
+
+      it_behaves_like "converts pubid to different formats"
+    end
+
+    context "NBS IR 79-1591-1" do
+      let(:original_pubid) { "NBS IR 79-1591-1" }
+      let(:short_pubid) { "NBS IR 79-1591pt1" }
+
+      it_behaves_like "converts pubid to different formats"
+    end
+
+    context "NBS IR 80-2111-1" do
+      let(:original_pubid) { "NBS IR 80-2111-1" }
+      let(:short_pubid) { "NBS IR 80-2111pt1" }
+
+      it_behaves_like "converts pubid to different formats"
+    end
+
+    context "NBS IR 84-2857-1" do
+      let(:original_pubid) { "NBS IR 84-2857-1" }
+      let(:short_pubid) { "NBS IR 84-2857pt1" }
+
+      it_behaves_like "converts pubid to different formats"
+    end
+
     context "when cannot parse code" do
       it "should raise error" do
         expect { described_class.parse("NIST SP WRONG-CODE") }


### PR DESCRIPTION
related #125 

Fixes for:
```
✅ | NBS IR 74-577r1 | NBS IR 74-577-1 | ✅ | NBS.IR.74-577r1 | NBS.IR.74-577-1 | Remittance processing system, volume I (refer to volume II)
✅ | NBS IR 74-577r2 | NBS IR 74-577-2 | ✅ | NBS.IR.74-577r2 | NBS.IR.74-577-2 | Remittance processing system, volume II (reference volume I)
✅ | NBS IR 77-1420r1 | NBS IR 77-1420-1 | ✅ | NBS.IR.77-1420r1 | NBS.IR.77-1420-1 | NBS minimal BASIC test programs- Version 1 user's manual : Volume 1- test system overview
✅ | NBS IR 77-1420r2 | NBS IR 77-1420-2 | ✅ | NBS.IR.77-1420r2 | NBS.IR.77-1420-2 | NBS minimal BASIC test programs - Version 1 user's manual : Volume 2 - general program structure, outpu
✅ | NBS IR 77-1420r3 | NBS IR 77-1420-3 | ✅ | NBS.IR.77-1420r3 | NBS.IR.77-1420-3 | NBS minimal BASIC test programs - Version 1 user's manual : Volume 3 - control statements, data structu
✅ | NBS IR 77-1420r4 | NBS IR 77-1420-4 | ✅ | NBS.IR.77-1420r4 | NBS.IR.77-1420-4 | NBS minimal BASIC test programs - Version 1 user's manual : Volume 4 - mathematical and user defined fu
```

```
✅ | NBS IR 79-1591r1 | NBS IR 79-1591-1 | ✅ | NBS.IR.79-1591r1 | NBS.IR.79-1591-1 | Semiconductor technology program : progress briefs
✅ | NBS IR 79-1591r2 | NBS IR 79-1591-2 | ✅ | NBS.IR.79-1591r2 | NBS.IR.79-1591-2 | Semiconductor technology program : progress briefs
✅ | NBS IR 79-1591r3 | NBS IR 79-1591-3 | ✅ | NBS.IR.79-1591r3 | NBS.IR.79-1591-3 | Semiconductor technology program : progress briefs
```

```
✅ | NBS IR 80-2111r1 | NBS IR 80-2111-1 | ✅ | NBS.IR.80-2111r1 | NBS.IR.80-2111-1 | Review and refinement of ATC 3-06 tentative seismic provisions : report of Technical Committee 1 : seis
✅ | NBS IR 80-2111r11 | NBS IR 80-2111-11 | ✅ | NBS.IR.80-2111r11 | NBS.IR.80-2111-11 | Review and refinement of ATC 3-06 tentative seismic provisions : report of Joint Committee on Revie
✅ | NBS IR 80-2111r2 | NBS IR 80-2111-2 | ✅ | NBS.IR.80-2111r2 | NBS.IR.80-2111-2 | Review and refinement of ATC 3-06 tentative seismic provisions : report of Technical Committee 2 : stru
✅ | NBS IR 80-2111r3 | NBS IR 80-2111-3 | ✅ | NBS.IR.80-2111r3 | NBS.IR.80-2111-3 | Review and refinement of ATC 3-06 tentative seismic provisions : report of Technical Committee 3 : foun
```

```
✅ | NBS IR 84-2857r1 | NBS IR 84-2857-1 | ✅ | NBS.IR.84-2857r1 | NBS.IR.84-2857-1 | Center for electronics and electrical engineering : technical progress bulletin covering center program
✅ | NBS IR 84-2857r2 | NBS IR 84-2857-2 | ✅ | NBS.IR.84-2857r2 | NBS.IR.84-2857-2 | Center for electronics and electrical engineering : technical progress bulletin covering center program
✅ | NBS IR 84-2857r3 | NBS IR 84-2857-3 | ✅ | NBS.IR.84-2857r3 | NBS.IR.84-2857-3 | Center for electronics and electrical engineering : technical progress bulletin covering center program
```
